### PR TITLE
Upgrade to use `concurrent-ruby` instead of `atomic`

### DIFF
--- a/lib/peek/views/mysql2.rb
+++ b/lib/peek/views/mysql2.rb
@@ -1,13 +1,13 @@
 require 'mysql2'
-require 'atomic'
+require 'concurrent/atomics'
 
 # Instrument SQL time
 class Mysql2::Client
   class << self
     attr_accessor :query_time, :query_count
   end
-  self.query_count = Atomic.new(0)
-  self.query_time = Atomic.new(0)
+  self.query_count = Concurrent::AtomicReference.new(0)
+  self.query_time = Concurrent::AtomicReference.new(0)
 
   def query_with_timing(*args)
     start = Time.now

--- a/peek-mysql2.gemspec
+++ b/peek-mysql2.gemspec
@@ -19,5 +19,6 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'peek'
   gem.add_dependency 'mysql2'
-  gem.add_dependency 'atomic', '>= 1.0.0'
+  gem.add_dependency 'concurrent-ruby'
+  gem.add_dependency 'concurrent-ruby-ext'
 end


### PR DESCRIPTION
atomic has been [deprecated](https://github.com/ruby-concurrency/atomic#deprecated) and superseded by [concurrent-ruby](https://github.com/ruby-concurrency/concurrent-ruby). This bumps
the dependencies to use concurrent ruby and do away with the atomic gem.

@dewski again, happy to litmus test this one.
