### PR TITLE
fixes deprecation warning for rails 5

### DIFF
--- a/lib/peek-mysql2/timing.rb
+++ b/lib/peek-mysql2/timing.rb
@@ -1,0 +1,15 @@
+module Peek
+  module Mysql2
+    module Timing
+      def query(*args)
+        start = Time.now
+        super(*args)
+      ensure
+        duration = (Time.now - start)
+        ::Mysql2::Client.query_time.update { |value| value + duration }
+        ::Mysql2::Client.query_count.update { |value| value + 1 }
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
hi dewski.

in rails 5, alias_method_chain is deprecated.
It shows warning, like this.

> DEPRECATION WARNING: alias_method_chain is deprecated. Please, use Module#prepend instead. From module, you can access the original method using super. (called from ***.rb:123)

I need to remove its warning.
If you like it, please merge.

Thanks.
